### PR TITLE
Add Stationcount observation data to the database

### DIFF
--- a/CCDRS.Net.sln
+++ b/CCDRS.Net.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CCDRS", "CCDRS\CCDRS.csproj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CCDRSManager", "CCDRSManager\CCDRSManager.csproj", "{172FA2FB-C707-4ECD-A403-8DF4F71CB3A2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CCDRSManagerTests", "CCDRSManagerTests\CCDRSManagerTests.csproj", "{63F82869-A38B-4C90-9B34-F0D1414B12D0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{172FA2FB-C707-4ECD-A403-8DF4F71CB3A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{172FA2FB-C707-4ECD-A403-8DF4F71CB3A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{172FA2FB-C707-4ECD-A403-8DF4F71CB3A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63F82869-A38B-4C90-9B34-F0D1414B12D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63F82869-A38B-4C90-9B34-F0D1414B12D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63F82869-A38B-4C90-9B34-F0D1414B12D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63F82869-A38B-4C90-9B34-F0D1414B12D0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CCDRSManager/App.xaml.cs
+++ b/CCDRSManager/App.xaml.cs
@@ -23,14 +23,9 @@ namespace CCDRSManager
     /// </summary>
     public partial class App : Application
     {
-        private readonly CCDRSContext _context = new CCDRSContext();
-        public CCDRSManagerModelRepository CCDRSManagerModelRepository { get; }
-
-        public static App Us { get; private set; } = null!;
         public App()
         {
-            CCDRSManagerModelRepository = new CCDRSManagerModelRepository(_context);
-            Us = this;
+            Configuration.Initialize();
         }
 
         protected override void OnStartup(StartupEventArgs e)

--- a/CCDRSManager/CCDRSManagerModelRepository.cs
+++ b/CCDRSManager/CCDRSManagerModelRepository.cs
@@ -15,22 +15,35 @@
 
 using CCDRSManager.Data;
 using CCDRSManager.Model;
+using Microsoft.AspNetCore.Http;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.IdentityFramework;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.PerformanceData;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Xceed.Wpf.AvalonDock.Themes;
 
 namespace CCDRSManager;
 
 /// <summary>
 /// Class to provides access to the persistent storage?
 /// </summary>
-public class CCDRSManagerModelRepository
+public partial class CCDRSManagerModelRepository
 {
     private readonly CCDRSContext _context;
-    private ObservableCollection<RegionModel> _regionsModel;
+    private readonly ObservableCollection<RegionModel> _regionsModel;
 
     // Initialize the CCDRS class
     public CCDRSManagerModelRepository(CCDRSContext context)
@@ -44,7 +57,7 @@ public class CCDRSManagerModelRepository
     /// </summary>
     public ReadOnlyObservableCollection<RegionModel> Regions
     {
-        get => new ReadOnlyObservableCollection<RegionModel>(_regionsModel);
+        get => new(_regionsModel);
     }
     
     /// <summary>
@@ -83,15 +96,6 @@ public class CCDRSManagerModelRepository
     }
 
     /// <summary>
-    /// Save the changes to the context to the database when all context changes have finished.
-    /// </summary>
-    /// <returns></returns>
-    public async Task SaveData()
-    {
-        _context.SaveChangesAsync();
-    }
-
-    /// <summary>
     /// Add survey data to the database.
     /// </summary>
     /// <param name="regionId">Primary serial key of regionId as an integer.</param>
@@ -99,9 +103,11 @@ public class CCDRSManagerModelRepository
     public void AddSurveyData(int regionId, int surveyYear)
     {
         // Create a new survey object.
-        Survey survey = new Survey();
-        survey.RegionId = regionId;
-        survey.Year = surveyYear;
+        Survey survey = new()
+        {
+            RegionId = regionId,
+            Year = surveyYear
+        };
         _context.Surveys.Add(survey);
         _context.SaveChanges();
     }
@@ -119,7 +125,7 @@ public class CCDRSManagerModelRepository
                               join regions in _context.Regions on stations.RegionId equals regions.Id
                               where
                                 regions.Id == regionId
-                                && stations.StationCode == stationCode
+                                && stations.StationCode == stationCode.Trim()
                               select
                                 stations).Any();
 
@@ -127,9 +133,11 @@ public class CCDRSManagerModelRepository
         if (stationExists == false)
         {
             // Add new station code to the Stations context.
-            Station newStation = new Station();
-            newStation.StationCode = stationCode;
-            newStation.Description = stationDescription;
+            Station newStation = new()
+            {
+                StationCode = stationCode,
+                Description = stationDescription
+            };
             _context.Stations.Add(newStation);
             _context.SaveChanges();
         }
@@ -143,7 +151,6 @@ public class CCDRSManagerModelRepository
     public void AddStationData(string stationFileName, int regionId)
     {
         // Loop through the station csv file
-        string[] data;
         using (var readFile = new StreamReader(stationFileName))
         {
             string? line;
@@ -160,7 +167,7 @@ public class CCDRSManagerModelRepository
     }
 
     /// <summary>
-    /// Add the surveysstation data of new survey to the database.
+    /// Add the surveys_station data of new survey to the database.
     /// </summary>
     /// <param name="regionId">Primary serial key of the region.</param>
     /// <param name="surveyYear">Year of survey e.g. 2022.</param>
@@ -174,7 +181,7 @@ public class CCDRSManagerModelRepository
                             && surveys.Year == surveyYear
                         select
                             surveys
-                        ).FirstOrDefault();
+                        ).First();
 
         //find stations list of all stations of specific region
         var stationList = (from stations in _context.Stations
@@ -187,12 +194,223 @@ public class CCDRSManagerModelRepository
         //combine the survey with the stationList to make the new surveystation context.
         foreach (var station in stationList)
         {
-            SurveyStation ss = new SurveyStation();
-            ss.StationId = station.Id;
-            ss.SurveyId = surveyID.Id;
+            SurveyStation ss = new()
+            {
+                StationId = station.Id,
+                SurveyId = surveyID.Id
+            };
             _context.SurveyStations.Add(ss);
         }
         //save the context to the database.
         _context.SaveChanges();
     }
+
+    /// <summary>
+    /// Checks if the vehicle type exists in the database
+    /// </summary>
+    /// <param name="header">Name of vehicle type as a string.</param>
+    /// <param name="vehicleResult">A VehicleCountType object.</param>
+    /// <returns>true if a VehicleCountType object is found else false.</returns>
+    public bool TryGetVehicle(string header, [NotNullWhen(true)] out VehicleCountType? vehicleResult)
+    {
+        Regex re = MyRegex();
+        Match regexValue = re.Match(header);
+
+        // Regex match found so do two queries
+        // One against the vehicle table and one against the vehicle_count_type table
+        if (regexValue.Success)
+        {
+            // first check against the 
+            string vehicleName = regexValue.Groups[1].Value;
+            int vehicleNumber = int.Parse(regexValue.Groups[2].Value);
+
+            // run the query to find the vehicle Id
+            var vehicle = _context.Vehicles.Where(v => v.Name == vehicleName).FirstOrDefault();
+            if (vehicle is null)
+            {
+                vehicleResult = null;
+                return false;
+            }
+            vehicleResult = _context.VehicleCountTypes.Where(v => v.VehicleId == vehicle.Id && v.Occupancy == vehicleNumber).FirstOrDefault();
+            return vehicleResult is not null;
+        }
+        else
+        {
+            // No regex match found so query the vehicle table to see if the vehicle exists.
+            var vehicle = _context.Vehicles.Where(v => v.Name == header).FirstOrDefault();
+            if (vehicle is null)
+            {
+                vehicleResult = null;
+                return false;
+            }
+            vehicleResult = _context.VehicleCountTypes.Where(v => v.VehicleId == vehicle.Id && v.Occupancy == 1).FirstOrDefault();
+            return vehicleResult is not null;
+        }
+    }
+
+    /// <summary>
+    /// Method which creates a new StationCountObservation object and appends the new items to the context.
+    /// </summary>
+    /// <param name="vehicleCountTypeList">List of all VehicleCountTypeObjects found in the file.</param>
+    /// <param name="observation">The count observed for each VehicleCountType passed in as a list.</param>
+    /// <param name="regionId">Primary serial key of region as int.</param>
+    /// <param name="surveyYear">Year of survey e.g. 2016.</param>
+    public void InsertDataIntoStationCountContext(List<VehicleCountType> vehicleCountTypeList, string[] observation, int regionId, int surveyYear)
+    {
+        // get the survey station data object
+        var surveyStation = (from surveyStations in _context.SurveyStations
+                             join stations in _context.Stations on surveyStations.StationId equals stations.Id
+                             join region in _context.Regions on stations.RegionId equals region.Id
+                             join survey in _context.Surveys on surveyStations.SurveyId equals survey.Id
+                             where
+                               region.Id == regionId
+                               && survey.Year == surveyYear
+                               && stations.StationCode == observation[0].Trim()
+                             select
+                               surveyStations
+                      ).First();
+
+        // Iterate over the list of all vehicle types
+        foreach (var vehicleCountType in vehicleCountTypeList)
+        {
+            // Find the index of the vehicle_count_type object
+            int ind = vehicleCountTypeList.IndexOf(vehicleCountType);
+            if (observation[ind + 2] != "0")
+            {
+                StationCountObservation stationCountObservation = new()
+                {
+                    SurveyStationId = surveyStation.Id,
+                    Time = Int32.Parse(observation[1]),
+                    VehicleCountTypeId = vehicleCountType.Id,
+                    Observation = Int32.Parse(observation[ind + 2])
+                };
+                _context.StationCountObservations.Add(stationCountObservation);
+            }
+        }
+
+    }
+
+    /// <summary>
+    /// Add StationCountObservation data to the database.
+    /// </summary>
+    /// <param name="stationCountObservationFile">String filepath to the stationcount observation csv file.</param>
+    /// <param name="regionId">Primary serial key of region.</param>
+    /// <param name="surveyYear">Year of survey e.g.2016.</param>
+    /// <param name="checkIfAdd">Function to check if the vehicle type exist in the database or not.</param>
+    /// <exception cref="NotImplementedException"></exception>
+    public void AddStationCountObservationData(string stationCountObservationFile, int regionId, int surveyYear, Func<string, bool>?checkIfAdd=null)
+    {
+        string[] headerLine;
+        
+        List<VehicleCountType> vehicleCountTypeList = new();
+
+        // read the station_count_observation ccdrs csv file
+        using (var readFile = new StreamReader(stationCountObservationFile))
+        {
+            string? line;
+            string[] observationData;
+
+            // Extract the header of the csv file which contains the columns of vehicle types.
+            headerLine = readFile.ReadLine().Split(',');
+
+            // Loop through header to check if the vehicle exists in the database or not
+            foreach (string technology in headerLine)
+            {
+                // Ignore if the header value is labeled station or time 
+                if (technology == "station" || technology == "time")
+                {
+                    continue;
+                }
+                else
+                {
+                    if (TryGetVehicle(technology, out var vehicleCount))
+                    {
+                        vehicleCountTypeList.Add(vehicleCount);
+                    }
+                    else
+                    {
+                        if (checkIfAdd?.Invoke(technology) == true)
+                        {
+                            // ToDo: Need to implement.
+                            // If user selects yes we add the technology to the vehicle_count_type
+                        }
+                        else
+                        {
+                            // ToDo: Need to implement
+                            // if user selects no, don't add new technologies and gracefully abort.
+                        }
+                        throw new NotImplementedException();
+                    }
+                }
+            }
+
+            // Loop through the remaining rows of data and insert the observation data into the database.
+            while ((line = readFile.ReadLine()) is not null)
+            {
+                observationData = line.Split(',');
+                // check and add the station data
+                InsertDataIntoStationCountContext(vehicleCountTypeList, observationData, regionId, surveyYear);
+            }
+        }
+        // Update the individaul_categories table to display the correct technologies on webpage.
+        UpdateIndividualCategoriesTable(regionId, surveyYear, vehicleCountTypeList);
+        
+        // Save the changes to the database.
+        SaveData();
+    }
+
+    /// <summary>
+    /// Update the individual_categories table with the correct technologies to display to the html 
+    /// front end.
+    /// </summary>
+    /// <param name="regionId">Primary serial key of region as an int.</param>
+    /// <param name="surveyYear">Year of survey e.g. 2016</param>
+    /// <param name="vehicleCountTypes">List of VehicleCountTypes for which observations were collected for the given 
+    /// specific survey.</param>
+    public void UpdateIndividualCategoriesTable(int regionId, int surveyYear, List<VehicleCountType> vehicleCountTypes)
+    {
+        var region = _context.Regions.Where(r => r.Id == regionId).First();
+        var survey = _context.Surveys.Where(s => s.Year == surveyYear && s.RegionId == regionId).First();
+
+        // Delete the individual category of specific survey of data that was previously uploaded.
+        List<IndividualCategory> individualCategories = (from individualcategories in _context.IndividualCategories
+                                                         where
+                                                             individualcategories.RegionId == regionId
+                                                             && individualcategories.Year == surveyYear
+                                                         select
+                                                             individualcategories).ToList();
+        _context.IndividualCategories.RemoveRange(individualCategories);
+        _context.SaveChanges();
+
+        // Iterate over the new vehicle_count_type list and build a new set of individual categories
+        foreach (VehicleCountType vehicleCountType in vehicleCountTypes)
+        {
+            var vehicle = _context.Vehicles.Where(v => v.Id == vehicleCountType.VehicleId).First();
+            IndividualCategory iC = new()
+            {
+                RegionId = region.Id,
+                RegionName = region.Name,
+                SurveyId = survey.Id,
+                Year = survey.Year,
+                CountType = vehicleCountType.CountType,
+                Occupancy = vehicleCountType.Occupancy,
+                Description = vehicleCountType.Description,
+                VehicleCountTypeId = vehicleCountType.Id,
+                VehicleName = vehicle.Name
+            };
+            _context.IndividualCategories.Add(iC);
+        }
+    }
+
+    /// <summary>
+    /// Save the changes to the context to the database when all context changes have finished.
+    /// </summary>
+    /// <returns></returns>
+    public Task SaveData()
+    {
+        return _context.SaveChangesAsync();
+    }
+
+    [GeneratedRegex("([a-zA-Z]+)(\\d+)")]
+    private static partial Regex MyRegex();
 }

--- a/CCDRSManager/CCDRSManagerModelRepository.cs
+++ b/CCDRSManager/CCDRSManagerModelRepository.cs
@@ -15,25 +15,14 @@
 
 using CCDRSManager.Data;
 using CCDRSManager.Model;
-using Microsoft.AspNetCore.Http;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations.Operations;
-using Microsoft.EntityFrameworkCore.Query.Internal;
-using Microsoft.IdentityFramework;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.PerformanceData;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Xceed.Wpf.AvalonDock.Themes;
 
 namespace CCDRSManager;
 
@@ -59,7 +48,7 @@ public partial class CCDRSManagerModelRepository
     {
         get => new(_regionsModel);
     }
-    
+
     /// <summary>
     /// Checks if the survey exists or not.
     /// </summary>
@@ -67,12 +56,12 @@ public partial class CCDRSManagerModelRepository
     {
         // find one instance of the survey data
         return (from surveys in _context.Surveys
-                        join regions in _context.Regions on surveys.RegionId equals regions.Id
-                        where
-                           regions.Id == regionId
-                           && surveys.Year == surveyYear
-                        select
-                          surveys
+                join regions in _context.Regions on surveys.RegionId equals regions.Id
+                where
+                   regions.Id == regionId
+                   && surveys.Year == surveyYear
+                select
+                  surveys
                 ).Any();
     }
 
@@ -122,12 +111,12 @@ public partial class CCDRSManagerModelRepository
     {
         // Check if stationCode exists in database.
         var stationExists = (from stations in _context.Stations
-                              join regions in _context.Regions on stations.RegionId equals regions.Id
-                              where
-                                regions.Id == regionId
-                                && stations.StationCode == stationCode.Trim()
-                              select
-                                stations).Any();
+                             join regions in _context.Regions on stations.RegionId equals regions.Id
+                             where
+                               regions.Id == regionId
+                               && stations.StationCode == stationCode.Trim()
+                             select
+                               stations).Any();
 
         // Add new stationCode to the stations context if stationExists return False.
         if (stationExists == false)
@@ -298,10 +287,10 @@ public partial class CCDRSManagerModelRepository
     /// <param name="surveyYear">Year of survey e.g.2016.</param>
     /// <param name="checkIfAdd">Function to check if the vehicle type exist in the database or not.</param>
     /// <exception cref="NotImplementedException"></exception>
-    public void AddStationCountObservationData(string stationCountObservationFile, int regionId, int surveyYear, Func<string, bool>?checkIfAdd=null)
+    public void AddStationCountObservationData(string stationCountObservationFile, int regionId, int surveyYear, Func<string, bool>? checkIfAdd = null)
     {
         string[] headerLine;
-        
+
         List<VehicleCountType> vehicleCountTypeList = new();
 
         // read the station_count_observation ccdrs csv file
@@ -354,7 +343,7 @@ public partial class CCDRSManagerModelRepository
         }
         // Update the individaul_categories table to display the correct technologies on webpage.
         UpdateIndividualCategoriesTable(regionId, surveyYear, vehicleCountTypeList);
-        
+
         // Save the changes to the database.
         SaveData();
     }

--- a/CCDRSManager/CCDRSManagerViewModel.cs
+++ b/CCDRSManager/CCDRSManagerViewModel.cs
@@ -28,7 +28,7 @@ public class CCDRSManagerViewModel : INotifyPropertyChanged
     /// <summary>
     /// ccdrsRepository variable used and accessed by all methods.
     /// </summary>
-    private readonly CCDRSManagerModelRepository _ccdrsRepository = App.Us.CCDRSManagerModelRepository;
+    private readonly CCDRSManagerModelRepository _ccdrsRepository = Configuration.CCDRSManagerModelRepository;
 
     /// <summary>
     /// Observable List of all regions that exist in the database.
@@ -88,6 +88,20 @@ public class CCDRSManagerViewModel : INotifyPropertyChanged
 
     }
 
+    private string _stationCountObservationFile;
+    public string StationCountObservationFile
+    {
+        get
+        {
+            return _stationCountObservationFile;
+        }
+        set
+        {
+            _stationCountObservationFile = value;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(StationCountObservationFile)));
+        }
+    }
+
     /// <summary>
     /// Controls access to the CCDRS model repository.
     /// </summary>
@@ -134,5 +148,13 @@ public class CCDRSManagerViewModel : INotifyPropertyChanged
     public void AddSurveyStationData()
     {
         _ccdrsRepository.AddSurveyStationData(RegionId, SurveyYear);
+    }
+
+    /// <summary>
+    /// Add StationCountObservation data to the database.
+    /// </summary>
+    public void AddStationCountObserationData()
+    {
+        _ccdrsRepository.AddStationCountObservationData(StationCountObservationFile, RegionId, SurveyYear);
     }
 }

--- a/CCDRSManager/CCDRSWizard.xaml
+++ b/CCDRSManager/CCDRSWizard.xaml
@@ -45,7 +45,6 @@
                         Text="{Binding Path=StationFileName, UpdateSourceTrigger=PropertyChanged}"
                         />
                     <Button Click="AddStationData" Content="Add Station Data" />
-                    
                 </StackPanel>
             </xctk:WizardPage>
 
@@ -57,7 +56,9 @@
                     <Button Name="OpenFile"
                         Content="Upload StationCount File" 
                         Click="OpenStationCountFile"/>
-                    <TextBox Name="FileName" />
+                    <TextBox Name="StationCountObservationFile" 
+                         Text="{Binding Path=StationCountObservationFile, UpdateSourceTrigger=PropertyChanged}"/>
+                    <Button Click="AddStationCountObservationData" Content="Add StationCount Observation Data" />
                 </StackPanel>
             </xctk:WizardPage>
         </xctk:Wizard>

--- a/CCDRSManager/CCDRSWizard.xaml.cs
+++ b/CCDRSManager/CCDRSWizard.xaml.cs
@@ -112,7 +112,7 @@ namespace CCDRSManager
         /// <param name="e"></param>
         private void OpenStationCountFile(object sender, RoutedEventArgs e)
         {
-            OpenFileDialog(FileName);
+            OpenFileDialog(StationCountObservationFile);
         }
 
         /// <summary>
@@ -130,6 +130,20 @@ namespace CCDRSManager
                 MessageBox.Show(this, "Successfully added survey and station data to the database.");
             }
 
+        }
+
+        /// <summary>
+        /// Add StationCountObservation data to the database.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void AddStationCountObservationData(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is CCDRSManagerViewModel vm)
+            {
+                vm.AddStationCountObserationData();
+                MessageBox.Show(this, "Successfully added station count observation data to the database.Press Finish and close the wizard.");
+            }
         }
     }
 }

--- a/CCDRSManager/Configuration.cs
+++ b/CCDRSManager/Configuration.cs
@@ -1,4 +1,19 @@
-﻿using CCDRSManager.Data;
+﻿/*
+    Copyright 2023 University of Toronto
+    This file is part of CCDRS.
+    CCDRS is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    CCDRS is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with CCDRS.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using CCDRSManager.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/CCDRSManager/Configuration.cs
+++ b/CCDRSManager/Configuration.cs
@@ -1,0 +1,19 @@
+﻿using CCDRSManager.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CCDRSManager;
+
+public static class Configuration
+{
+    private static readonly CCDRSContext _context = new CCDRSContext();
+    public static CCDRSManagerModelRepository CCDRSManagerModelRepository { get; private set; }
+
+    public static void Initialize()
+    {
+        CCDRSManagerModelRepository = new CCDRSManagerModelRepository(_context);
+    }
+}

--- a/CCDRSManager/Data/CCDRSContext.cs
+++ b/CCDRSManager/Data/CCDRSContext.cs
@@ -17,7 +17,6 @@ using System;
 using System.Collections.Generic;
 using CCDRSManager.Model;
 using Microsoft.EntityFrameworkCore;
-using CCDRSManager.Model;
 using System.Configuration;
 
 namespace CCDRSManager.Data;

--- a/CCDRSManager/RegionModel.cs
+++ b/CCDRSManager/RegionModel.cs
@@ -39,6 +39,8 @@ namespace CCDRSManager
             Id = region.Id;
             Name = region.Name;
         }
+#pragma warning disable CS0067
         public event PropertyChangedEventHandler? PropertyChanged;
+#pragma warning restore CS0067
     }
 }

--- a/CCDRSManagerTests/CCDRSManagerModelRepositoryTests.cs
+++ b/CCDRSManagerTests/CCDRSManagerModelRepositoryTests.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CCDRSManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CCDRSManager.Tests
+{
+    [TestClass()]
+    public class CCDRSManagerModelRepositoryTests
+    {
+        [Microsoft.VisualStudio.TestTools.UnitTesting.AssemblyInitialize]
+        public void StartUp()
+        {
+            Configuration.Initialize();
+        }
+
+        [TestMethod()]
+        public void TryGetVehicleTest()
+        {
+            Assert.Fail();
+        }
+    }
+}

--- a/CCDRSManagerTests/CCDRSManagerTests.csproj
+++ b/CCDRSManagerTests/CCDRSManagerTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CCDRSManager\CCDRSManager.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
User can upload stationcount data and the system can add the enw stationcount data to the stationcount table. Created a blank unittest file now and cleaned up the codebase
ToDo: Ability to notify user of a new technology and add that to the database will be implemented in a separate new PR.