### PR TITLE
True min and max timestamps for specific station and screenline

### DIFF
--- a/CCDRS/Pages/SpecificScreenline.cshtml.cs
+++ b/CCDRS/Pages/SpecificScreenline.cshtml.cs
@@ -316,16 +316,23 @@ namespace CCDRS.Pages
                                 && stationcount.Time >= startTime & stationcount.Time <= endTime
                                 && individualCategorySelect.Contains(vehiclecount.Id)
                             group new { screenline, stationcount, vehicle, vehiclecount, station }
-                            by new { screenline.SlineCode, vehicle.Name, vehiclecount.Occupancy, vehiclecount.Id, station.Direction }
+                            by new { screenline.SlineCode, vehicle.Name, vehiclecount.Occupancy, 
+                                vehiclecount.Id, station.Direction, stationcount.Time }
                             into grp
                             select new
                             {
                                 SlineCode = grp.Key.SlineCode,
                                 Observations = grp.Sum(x => x.stationcount.Observation),
                                 VehicleCountTypeId = grp.Key.Id,
-                                Direction = grp.Key.Direction
+                                Direction = grp.Key.Direction,
+                                Time = grp.Key.Time
                             }
                       );
+
+            // Get the minimum and maximum timestamps from the selected dataset.
+            var minimumStartTime = datalist.Min(x => x.Time);
+            var maximumEndTime = datalist.Max(x => x.Time);
+
             foreach (var item in datalist)
             {
                 if (!newlist.TryGetValue((item.SlineCode, item.Direction), out var counts))
@@ -346,9 +353,9 @@ namespace CCDRS.Pages
                 builder.Append(',');
                 builder.Append(item.direction);
                 builder.Append(',');
-                builder.Append(startTime);
+                builder.Append(minimumStartTime);
                 builder.Append(',');
-                builder.Append(endTime);
+                builder.Append(maximumEndTime);
                 foreach (var x in row)
                 {
                     builder.Append(',');

--- a/CCDRS/Pages/SpecificStation.cshtml.cs
+++ b/CCDRS/Pages/SpecificStation.cshtml.cs
@@ -318,16 +318,24 @@ namespace CCDRS.Pages
                                 surveys.Id == SelectedSurveyId &
                                 stationCounts.Time > startTime & stationCounts.Time <= endTime &
                                 individualCategorySelect.Contains(vehicleCountTypes.Id)
-                            group new { stationCounts, vehicleCountTypes, stations, vehicles } by new { stations.StationCode, vehicles.Name, vehicleCountTypes.Occupancy, vehicleCountTypes.Id }
+                            group new { stationCounts, vehicleCountTypes, stations, vehicles } 
+                            by new { stations.StationCode, vehicles.Name, vehicleCountTypes.Occupancy, 
+                                vehicleCountTypes.Id, stationCounts.Time }
                             into groupedBystationCountObservations
                             select new
                             {
                                 Station = groupedBystationCountObservations.Key.StationCode,
                                 Observations = groupedBystationCountObservations.Sum(x => x.stationCounts.Observation),
                                 VehicleCountTypeId = groupedBystationCountObservations.Key.Id,
-                                groupedBystationCountObservations.Key.Occupancy
+                                groupedBystationCountObservations.Key.Occupancy,
+                                Time = groupedBystationCountObservations.Key.Time
                             }
                       );
+
+            // Get the minimum and maximum timestamps from the selected dataset.
+            var minimumStartTime = dataList.Min(x => x.Time);
+            var maximumEndTime = dataList.Max(x => x.Time);
+
             foreach (var item in dataList)
             {
                 if (!newlist.TryGetValue(item.Station, out var counts))
@@ -343,9 +351,9 @@ namespace CCDRS.Pages
                 var row = newlist[item];
                 builder.Append(item);
                 builder.Append(',');
-                builder.Append(startTime);
+                builder.Append(minimumStartTime);
                 builder.Append(',');
-                builder.Append(endTime);
+                builder.Append(maximumEndTime);
                 foreach (var x in row)
                 {
                     builder.Append(',');


### PR DESCRIPTION
fixed queries to be able to display the minimum and maximum start and end times